### PR TITLE
Added custom argument errors, for wrong number, type, or condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # spark
-Jupyter Lab ipython extension used for teaching the [https://schulichignite.com/](Schulich Ignite sessions).
+Jupyter Lab ipython extension used for teaching the [Schulich Ignite sessions](https://schulichignite.com/).
 
 ### Documentation
 Simple documentation for the library is provided in the [documentation.ipynb](https://github.com/Schulich-Ignite/spark/blob/main/documentation.ipynb) file.
@@ -21,7 +21,7 @@ Install NodeJS using one of the methods below:
 
 Next, you must install the required jupyter lab extensions
 ```shell
-jupyter labextension install @jupyter-widgets/jupyterlab-manager ipycanvas
+jupyter labextension install @jupyter-widgets/jupyterlab-manager ipycanvas ipyevents
 ```
 
 Now, either clone the repo and install a development version, or install the up-to-date version from PyPI

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="schulich-ignite",
-    version="0.0.10",
+    version="0.0.11",
     author="Schulich Ignite",
     author_email="info@shulichignite.com",
     description="Spark library for Shulich Ignite sessions",

--- a/spark/util/Errors.py
+++ b/spark/util/Errors.py
@@ -1,0 +1,67 @@
+
+class ArgumentError(Exception):
+
+    def __init__(self, message=""):
+        self.message = message
+        super().__init__(self.message)
+
+
+class ArgumentTypeError(ArgumentError):
+    def __init__(self, func_name, argument_name, allowed_types, actual_type, arg):
+        if type(argument_name) == str and len(argument_name) > 0:
+            argname = "{} to be of type".format(argument_name)
+        else:
+            argname = "type"
+        type_str = ""
+        if type(allowed_types) == list:
+            if len(allowed_types) == 1:
+                type_str += str(allowed_types[0])
+            elif len(allowed_types) == 2:
+                type_str += "{} or {}".format(*allowed_types)
+            else:
+                type_str = (", ".join("{}"*(len(allowed_types)-1))).format(*allowed_types[:-1])
+                type_str += ", or {}".format(allowed_types[-1])
+        else:
+            type_str = str(allowed_types)
+
+        self.message = "{} expected {} {}, got {} of type {}".format(
+            func_name, argname, type_str, arg, actual_type)
+        super().__init__(self.message)
+
+
+class ArgumentNumError(ArgumentError):
+    def __init__(self, func_name, allowed_nums, actual_num):
+        num_str = ""
+        if type(allowed_nums) == list:
+            if len(allowed_nums) == 1:
+                num_str += str(allowed_nums[0])
+            elif len(allowed_nums) == 2:
+                num_str += "{} or {}".format(*allowed_nums)
+            else:
+                num_str = (", ".join("{}"*(len(allowed_nums)-1))).format(*allowed_nums[:-1])
+                num_str += ", or {}".format(allowed_nums[-1])
+        else:
+            num_str = str(allowed_nums)
+        self.message = "{} expected {} arguments, got {}".format(
+            func_name,
+            num_str,
+            actual_num
+        )
+        super().__init__(self.message)
+
+
+class ArgumentConditionError(ArgumentError):
+    def __init__(self, func_name, arg_name, expected_condition, actual_value):
+        if type(arg_name) == str and len(arg_name) > 0:
+            argname = "{}".format(arg_name)
+        else:
+            argname = "argument"
+        self.message = "{} expected {} to match \"{}\", got {}".format(
+            func_name,
+            argname,
+            expected_condition,
+            actual_value
+        )
+        super().__init__(self.message)
+    pass
+


### PR DESCRIPTION
Argument error classes added for readability, changed functioning of helper 'type checking' functions. 

- `ArgumentError` is the generic type for issues with arguments
- `ArgumentNumError` is the error for the wrong number of arguments
- `ArgumentTypeError` is the error for the wrong type of argument
- `ArgumentConditionError` is the error for arguments failing some other test (e.g. a number bounded in [0,255])