### PR TITLE
Fixed print() int error

### DIFF
--- a/spark/core.py
+++ b/spark/core.py
@@ -196,7 +196,7 @@ class Core:
     # Prints output to embedded output box
     def print(self, msg):
         global _sparkplug_running
-        self.output_text += msg + "\n"
+        self.output_text += str(msg) + "\n"
 
         if _sparkplug_running:
             self.output_text_code.update(Code(self.output_text))


### PR DESCRIPTION
Didn't mean to close the previous pull request. Same fix, added string cast to msg in print() to allow for ints