### PR TITLE
Move drawing and helper functions to different files

### DIFF
--- a/spark/__init__.py
+++ b/spark/__init__.py
@@ -27,9 +27,9 @@ class IgniteMagic(Magics):
         for key, val in core.Core.global_constants.items():
             globals_dict[key] = val
 
-        # Copy global methods from Core object
-        for field in core.Core.global_fields:
-            globals_dict[field] = getattr(self.core_obj, field)
+        for field, mutable in core.Core.ignite_globals.items():
+            if not mutable:
+                globals_dict[field] = getattr(self.core_obj, field)
 
         # Execute the code inside the cell and inject the globals we defined.
         try:
@@ -40,13 +40,14 @@ class IgniteMagic(Magics):
         # Look at all methods defined by user, and see if they overwrote anything useful
         methods = {}
         for key, val in locals_dict.items():
-            if key in core.Core.global_methods:
-                methods[key] = val  # Track the global methods and pass to the core_obj.
-            elif key in core.Core.global_fields:
-                print('Error in cell: Attempted redefinition of immutable Spark global "{}".'.format(key))
-                return
+            mutable = core.Core.ignite_globals.get(key)
+            if mutable is None:
+                globals_dict[key] = val
+            elif mutable:
+                methods[key] = val
             else:
-                globals_dict[key] = val  # Copy locals to global to keep them available.
+                print(f'Error in cell: Attempted redefinition of immutable Spark global "{key}".')
+                return
 
         # Run bootstrap code
         self.core_obj.start(methods)

--- a/spark/core.py
+++ b/spark/core.py
@@ -16,7 +16,7 @@ from ipycanvas import Canvas, hold_canvas
 from ipywidgets import Button
 
 from .util import IpyExit
-from .util.decorators import extern, global_immut_names, global_mut_names, global_immut, global_mut
+from .util.decorators import extern, _ignite_globals, ignite_global
 
 DEFAULT_CANVAS_SIZE = (100, 100)
 FRAME_RATE = 30
@@ -32,10 +32,8 @@ class Core:
     global_constants = {
         "pi": pi
     }
-    
-    global_fields = global_immut_names
 
-    global_methods = global_mut_names
+    ignite_globals = _ignite_globals
 
     def __init__(self, globals_dict):
         self.status_text = display(Code(""), display_id=True)
@@ -77,12 +75,12 @@ class Core:
     ### Properties ###
 
     @property
-    @global_immut
+    @ignite_global
     def canvas(self):
         return self._globals_dict["canvas"]
 
     @property
-    @global_immut
+    @ignite_global
     def mouse_x(self):
         return self._globals_dict["mouse_x"]
 
@@ -91,7 +89,7 @@ class Core:
         self._globals_dict["mouse_x"] = val
 
     @property
-    @global_immut
+    @ignite_global
     def mouse_y(self):
         return self._globals_dict["mouse_y"]
 
@@ -100,7 +98,7 @@ class Core:
         self._globals_dict["mouse_y"] = val
 
     @property
-    @global_immut
+    @ignite_global
     def mouse_is_pressed(self):
         return self._globals_dict["mouse_is_pressed"]
 
@@ -109,7 +107,7 @@ class Core:
         self._globals_dict["mouse_is_pressed"] = val
 
     @property
-    @global_immut
+    @ignite_global
     def width(self):
         return self._globals_dict["width"]
 
@@ -119,7 +117,7 @@ class Core:
         self.canvas.width = val
 
     @property
-    @global_immut
+    @ignite_global
     def height(self):
         return self._globals_dict["height"]
 
@@ -219,7 +217,7 @@ class Core:
 
     # Prints output to embedded output box
     # Can't use @validate_args decorator for functions actually accepting variable arguments
-    @global_immut
+    @ignite_global
     def print(self, *args, sep=' ', end='\n', flush=True):
         global _sparkplug_running
         self.output_text += sep.join([str(arg) for arg in args]) + end
@@ -260,20 +258,21 @@ class Core:
         self.stop()
 
     ### User overrideable functions ###
+
     # The function bodies here do not matter, they are discarded
-    @global_mut
+    @ignite_global(mutable=True)
     def setup(self): pass
 
-    @global_mut
+    @ignite_global(mutable=True)
     def draw(self): pass
 
-    @global_mut
+    @ignite_global(mutable=True)
     def mouse_up(self): pass
 
-    @global_mut
+    @ignite_global(mutable=True)
     def mouse_down(self): pass
 
-    @global_mut
+    @ignite_global(mutable=True)
     def mouse_moved(self): pass
 
     ### Global functions ###
@@ -392,7 +391,8 @@ class Core:
 
     ### Helper Functions ###
 
-    # Parse a string, rgb or rgba input into an HTML color string
+    # From util.helper_functions.misc_functions
+
     @extern
     def parse_color(self, *args, func_name="parse_color"): pass
 

--- a/spark/core.py
+++ b/spark/core.py
@@ -8,20 +8,15 @@
 import threading
 import time
 
-from math import pi, sin, cos, sqrt
+from math import pi
 import re
 
 from IPython.display import Code, display
 from ipycanvas import Canvas, hold_canvas
 from ipywidgets import Button
-from numbers import Real
-
-import random
 
 from .util import IpyExit
-from .util.HTMLColors import HTMLColors
-from .util.Errors import *
-from .util.decorators import *
+from .util.decorators import extern, global_immut_names, global_mut_names, global_immut, global_mut
 
 DEFAULT_CANVAS_SIZE = (100, 100)
 FRAME_RATE = 30
@@ -267,368 +262,148 @@ class Core:
     ### User overrideable functions ###
     # The function bodies here do not matter, they are discarded
     @global_mut
-    def setup(self):
-        pass
+    def setup(self): pass
 
     @global_mut
-    def draw(self):
-        pass
+    def draw(self): pass
 
     @global_mut
-    def mouse_up(self):
-        pass
+    def mouse_up(self): pass
 
     @global_mut
-    def mouse_down(self):
-        pass
+    def mouse_down(self): pass
 
     @global_mut
-    def mouse_moved(self):
-        pass
+    def mouse_moved(self): pass
 
     ### Global functions ###
 
-    # Sets canvas size
-    @validate_args([Real, Real])
-    @global_immut
-    def size(self, *args):
-        self.width = args[0]
-        self.height = args[1]
+    # From .util.helper_functions.canvas_functions
 
-    # Sets fill style
-    # 1 arg: HTML string value
-    # 3 args: r, g, b are int between 0 and 255
-    # 4 args: r, g, b, a, where r, g, b are ints between 0 and 255, and  a (alpha) is a float between 0 and 1.0
+    @extern
+    def size(self, *args): pass
 
-    @validate_args([str], [Real], [Real, Real, Real], [Real, Real, Real, Real])
-    @global_immut
-    def fill_style(self, *args):
-        self.canvas.fill_style = self.parse_color(func_name="fill_style", *args)
+    @extern
+    def fill_style(self): pass
 
-    @validate_args([str], [Real], [Real, Real, Real], [Real, Real, Real, Real])
-    @global_immut
-    def stroke_style(self, *args):
-        self.canvas.stroke_style = self.parse_color(func_name="stroke_style", *args)
+    @extern
+    def stroke_style(self, *args): pass
 
-    # Combines fill_rect and stroke_rect into one wrapper function
+    @extern
+    def clear(self, *args): pass
 
-    @validate_args([Real, Real, Real, Real])
-    @global_immut
-    def rect(self, *args):
-        self.canvas.fill_rect(*args)
-        self.canvas.stroke_rect(*args)
+    @extern
+    def background(self, *args): pass
 
-    # Similar to self.rect wrapper, except only accepts x, y and size
-    @validate_args([Real, Real, Real])
-    @global_immut
-    def square(self, *args):
-        self.rect(*args, args[2])
+    # From util.helper_functions.rect_functions
 
-    # Draws filled rect
-    @validate_args([Real, Real, Real, Real])
-    @global_immut
-    def fill_rect(self, *args):
-        self.canvas.fill_rect(*args)
+    @extern
+    def rect(self, *args): pass
 
-    # Strokes a rect
-    @validate_args([Real, Real, Real, Real])
-    @global_immut
-    def stroke_rect(self, *args):
-        self.canvas.stroke_rect(*args)
+    @extern
+    def fill_rect(self, *args): pass
 
-    # Clears a rect
-    @validate_args([Real, Real, Real, Real])
-    @global_immut
-    def clear_rect(self, *args):
-        self.canvas.clear_rect(*args)
+    @extern
+    def stroke_rect(self, *args): pass
 
-    # Draws circle at given coordinates
-    @validate_args([Real, Real, Real])
-    @global_immut
-    def circle(self, *args):
-        self.ellipse(*args, args[2])
+    @extern
+    def clear_rect(self, *args): pass
 
-    # Draws filled circle
-    @validate_args([Real, Real, Real])
-    @global_immut
-    def fill_circle(self, *args):
-        self.fill_ellipse(*args, args[2])
+    # From util.helper_functions.square_functions
 
-    # Draws circle stroke
-    @validate_args([Real, Real, Real])
-    @global_immut
-    def stroke_circle(self, *args):
-        self.stroke_ellipse(*args, args[2])
+    @extern
+    def square(self, *args): pass
 
-    @validate_args([Real, Real, Real, Real])
-    @global_immut
-    def ellipse(self, *args):
-        self.fill_ellipse(*args)
-        self.stroke_ellipse(*args)
+    @extern
+    def stroke_square(self, *args): pass
 
-    @validate_args([Real, Real, Real, Real])
-    @global_immut
-    def fill_ellipse(self, *args):
-        self.fill_arc(*args, 0, 2*pi)
+    @extern
+    def fill_square(self, *args): pass
 
-    @validate_args([Real, Real, Real, Real])
-    @global_immut
-    def stroke_ellipse(self, *args):
-        self.stroke_arc(*args, 0, 2*pi)
+    # From util.helper_functions.circle_functions
 
-    @validate_args([Real, Real, Real, Real],
-                   [Real, Real, Real, Real, Real],
-                   [Real, Real, Real, Real, Real, Real],
-                   [Real, Real, Real, Real, Real, Real, str])
-    @global_immut
-    def fill_arc(self, *args):
-        x, y, r, scale_x, scale_y, start, stop, mode = self.arc_args(*args)
+    @extern
+    def circle(self, *args): pass
 
-        if scale_x == 0 or scale_y == 0:
-            return
+    @extern
+    def fill_circle(self, *args): pass
 
-        self.canvas.translate(x,y)
-        self.canvas.scale(scale_x, scale_y)
+    @extern
+    def stroke_circle(self, *args): pass
 
-        if mode == "open" or mode == "chord":
-            self.canvas.fill_arc(0, 0, r, start, stop)
-        elif mode == "default" or mode == "pie":
-            self.canvas.begin_path()
-            start_x = r*cos(start)
-            start_y = r*sin(start)
-            self.canvas.move_to(start_x, start_y)
-            self.canvas.arc(0, 0, r, start, stop)
-            self.canvas.line_to(0,0)
-            self.canvas.close_path()
-            self.canvas.fill()
-            
-        self.canvas.scale(1/scale_x, 1/scale_y)
-        self.canvas.translate(-x, -y)
+    # From util.helper_functions.ellipse_functions
 
-    @validate_args([Real, Real, Real, Real],
-                   [Real, Real, Real, Real, Real],
-                   [Real, Real, Real, Real, Real, Real],
-                   [Real, Real, Real, Real, Real, Real, str])
-    @global_immut
-    def stroke_arc(self, *args):
-        x, y, r, scale_x, scale_y, start, stop, mode = self.arc_args(*args)
+    @extern
+    def ellipse(self, *args): pass
 
-        if scale_x == 0 or scale_y == 0:
-            return
+    @extern
+    def fill_ellipse(self, *args): pass
 
-        start_x = r*cos(start)
-        start_y = r*sin(start)
-        
-        self.canvas.translate(x,y)
-        self.canvas.scale(scale_x, scale_y)
+    @extern
+    def stroke_ellipse(self, *args): pass
 
-        self.canvas.begin_path()
-        self.canvas.move_to(start_x, start_y)
-        self.canvas.arc(0, 0, r, start, stop)
-        if mode == "open" or mode == "default":
-            self.canvas.move_to(start_x, start_y)
-        elif mode == "pie":
-            self.canvas.line_to(0, 0)
-        elif mode == "chord":
-            pass
-        self.canvas.close_path()
-        self.canvas.stroke()
-        
-        self.canvas.scale(1/scale_x, 1/scale_y)
-        self.canvas.translate(-x, -y)
+    # From util.helper_functions.arc_functions
 
-    @validate_args([Real, Real, Real, Real],
-                   [Real, Real, Real, Real, Real],
-                   [Real, Real, Real, Real, Real, Real],
-                   [Real, Real, Real, Real, Real, Real, str])
-    @global_immut
-    def arc(self, *args):
-        self.fill_arc(*args)
-        self.stroke_arc(*args)
+    @extern
+    def arc(self, *args): pass
 
-    @validate_args([Real, Real, Real, Real, Real, Real])
-    @global_immut
-    def fill_triangle(self, *args):
+    @extern
+    def fill_arc(self, *args): pass
 
-        self.canvas.begin_path()
-        self.canvas.move_to(args[0], args[1])
-        self.canvas.line_to(args[2], args[3])
-        self.canvas.line_to(args[4], args[5])
-        self.canvas.close_path()
-        self.canvas.fill()
+    @extern
+    def stroke_arc(self, *args): pass
 
-    @validate_args([Real, Real, Real, Real, Real, Real])
-    @global_immut
-    def stroke_triangle(self, *args):
+    # From util.helper_functions.triangle_functions
 
-        self.canvas.begin_path()
-        self.canvas.move_to(args[0], args[1])
-        self.canvas.line_to(args[2], args[3])
-        self.canvas.line_to(args[4], args[5])
-        self.canvas.close_path()
-        self.canvas.stroke()
+    @extern
+    def triangle(self, *args): pass
 
-    @validate_args([Real, Real, Real, Real, Real, Real])
-    @global_immut
-    def triangle(self, *args):
-        self.fill_triangle(*args)
-        self.stroke_triangle(*args)
+    @extern
+    def fill_triangle(self, *args): pass
 
-    @validate_args([int])
-    @global_immut
-    def text_size(self, *args):
-        self.font_settings['size'] = args[0]
-        self.canvas.font = f"{self.font_settings['size']}px {self.font_settings['font']}"
+    @extern
+    def stroke_triangle(self, *args): pass
 
-    @validate_args([str])
-    @global_immut
-    def text_align(self, *args):
-        if args[0] not in ['left', 'right', 'center']:
-            raise ArgumentConditionError("text_align", None, '"left", "right", or "center"', args[0])
+    # From util.helper_functions.text_functions
 
-        self.canvas.text_align = args[0]
+    @extern
+    def text_size(self, *args): pass
 
-    @validate_args([object, Real, Real])
-    @global_immut
-    def text(self, *args):
-        # Reassigning the properties gets around a bug with the properties not being used.
-        self.canvas.font = self.canvas.font
-        self.canvas.text_baseline = self.canvas.text_baseline
-        self.canvas.text_align = self.canvas.text_align
+    @extern
+    def text_align(self, *args): pass
 
-        self.canvas.fill_text(str(args[0]), args[1], args[2])
+    @extern
+    def text(self, *args): pass
 
-    @validate_args([Real, Real, Real, Real])
-    @global_immut
-    def draw_line(self, *args):
-        self.canvas.begin_path()
-        self.canvas.move_to(args[0], args[1])
-        self.canvas.line_to(args[2], args[3])
-        self.canvas.close_path()
-        self.canvas.stroke()
+    # From util.helper_functions.line_functions
 
-    # An alias to draw_line
-    @validate_args([Real, Real, Real, Real])
-    @global_immut
-    def line(self, *args):
-        self.draw_line(*args)
+    @extern
+    def draw_line(self, *args): pass
 
-    @validate_args([Real])
-    @global_immut
-    def line_width(self, *args):
-        self.canvas.line_width = args[0]
+    @extern
+    def line(self, *args): pass
+
+    @extern
+    def line_width(self, *args): pass
 
     # An alias to line_width
-    @validate_args([Real])
-    @global_immut
-    def stroke_width(self, *args):
-        self.line_width(*args)
-
-    # Clears canvas
-    @validate_args([])
-    @global_immut
-    def clear(self, *args):
-        self.canvas.clear()
-        
-    # Draws background on canvas
-    @validate_args([str], [Real], [Real, Real, Real], [Real, Real, Real, Real])
-    @global_immut
-    def background(self, *args):
-        fill = self.parse_color(func_name="background", *args)
-        old_fill = self.canvas.fill_style
-        self.canvas.fill_style = fill
-        self.canvas.fill_rect(0, 0, self.width, self.height)
-        self.canvas.fill_style = old_fill
+    @extern
+    def stroke_width(self, *args): pass
 
     ### Helper Functions ###
 
-    @staticmethod
-    def quote_if_string(val):
-        if type(val) is str:
-            return "\"{}\"".format(val)
-        else:
-            return val
-
     # Parse a string, rgb or rgba input into an HTML color string
-    @validate_args([str], [Real], [Real, Real, Real], [Real, Real, Real, Real])
-    def parse_color(self, *args, func_name="parse_color"):
-        argc = len(args)
+    @extern
+    def parse_color(self, *args, func_name="parse_color"): pass
 
-        if argc == 1:
-            if isinstance(args[0], Real):
-                n = int(Core.clip(args[0], 0, 255))
-                return f"rgb({n}, {n}, {n})"
-            elif isinstance(args[0], str):
-                return self.parse_color_string(func_name, args[0])
-            raise ArgumentConditionError(func_name, "", "Valid HTML format or color names", args[0])
-        elif argc == 3 or argc == 4:
-            color_args = [int(Core.clip(arg, 0, 255)) for arg in args[:3]]
+    @extern
+    def parse_color_string(self, func_name, s): pass
 
-            if argc == 3:
-                return "rgb({}, {}, {})".format(*color_args)
-            else:
-                # Clip alpha between 0 and 1
-                alpha_arg = self.clip(args[3], 0, 1.0)
-                return "rgba({}, {}, {}, {})".format(*color_args, alpha_arg)
-        else:
-            raise ArgumentNumError(func_name, [1, 3, 4], argc)
+    @extern
+    def arc_args(self, *args): pass
 
-    def parse_color_string(self, func_name, s):
-        rws = re.compile(r'\s')
-        no_ws = rws.sub('', s).lower()
-        # Check allowed color strings
-        if no_ws in HTMLColors:
-            return no_ws
-        elif no_ws in self.color_strings:
-            return self.color_strings[s]
-        # Check other HTML-permissible formats
-        else:
-            for regex in self.regexes:
-                if regex.fullmatch(no_ws) is not None:
-                    return no_ws
-        # Not in any permitted format
-        raise ArgumentConditionError(func_name, "", "Valid HTML format or color names",s)
+    @extern
+    def random(self, *args): pass
 
-    # Convert a tuple of circle args into arc args
-    @validate_args([Real, Real, Real])
-    def arc_args(self, *args):
-        argc = len(args)
-        x, y, w, h = args[:4]
-        defaults = [0, 2*pi, "default"]
-        start, stop, mode = [*args[4:argc], *defaults[argc-4:]]
-        while start < 0:
-            start += 2*pi
-        while start > 2*pi:
-            start -= 2*pi
-        while stop < 0:
-            stop += 2*pi
-        while stop > 2*pi:
-            stop += 2*pi
-        d = max(w, h)/2
-        
-        return x, y, d/2, w/d, h/d, start, stop, mode
-
-    @validate_args([])
-    @global_immut
-    # Global namespace alias of random.random()
-    def random(self, *args):
-        argc = len(args)
-        if argc != 0:
-            raise ArgumentNumError("random", 0, argc)
-        return random.random()
-
-    @validate_args([int])
-    @global_immut
-    # Global namespace alias of random.randint()
-    def randint(self, *args):
-        argc = len(args)
-        
-        if argc != 1:
-            raise ArgumentNumError("randint", 1, argc)
-
-        self.check_type_is_int(args[0])
-        return random.randint(0, args[0])
-    
-    @staticmethod
-    def clip(n, lb, ub):
-        return max(min(n, ub), lb)
+    @extern
+    def randint(self, *args): pass

--- a/spark/core.py
+++ b/spark/core.py
@@ -446,7 +446,7 @@ class Core:
         self.fill_arc(*args)
         self.stroke_arc(*args)
 
-    @validate_args([number, number, number, number, number, number])
+    @validate_args([Real, Real, Real, Real, Real, Real])
     @global_immut
     def fill_triangle(self, *args):
 

--- a/spark/util/core_methods.py
+++ b/spark/util/core_methods.py
@@ -1,0 +1,14 @@
+from .helper_functions.arc_functions import *
+from .helper_functions.canvas_functions import *
+from .helper_functions.circle_functions import *
+from .helper_functions.ellipse_functions import *
+from .helper_functions.line_functions import *
+from .helper_functions.misc_functions import *
+from .helper_functions.rect_functions import *
+from .helper_functions.square_functions import *
+from .helper_functions.text_functions import *
+from .helper_functions.triangle_functions import *
+
+
+def extern(func):
+    return globals()[f"helper_{func.__name__}"]

--- a/spark/util/decorators.py
+++ b/spark/util/decorators.py
@@ -6,7 +6,10 @@ def validate_args(*fmts, has_self=True):
     def decorator_validate_args(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            sig = FunctionSignature(func.__name__, fmts, has_self)
+            fname = func.__name__
+            if fname.startswith("helper_"):
+                fname = fname[7:]
+            sig = FunctionSignature(fname, fmts, has_self)
             sig.check_inputs(*args)
             return func(*args, **kwargs)
         return wrapper
@@ -18,9 +21,13 @@ global_immut_names = set()
 
 def global_immut(func):
     global global_immut_names
-    if func.__name__ in global_mut_names:
-        raise RuntimeError("Attempted to define {} as both mutable and immutable.".format(func.__name__))
-    global_immut_names.add(func.__name__)
+    if func.__name__.startswith("helper_"):
+        fname = func.__name__[7:]
+    else:
+        fname = func.__name__
+    if fname in global_mut_names:
+        raise RuntimeError("Attempted to define {} as both mutable and immutable.".format(fname))
+    global_immut_names.add(fname)
     return func
 
 
@@ -33,3 +40,6 @@ def global_mut(func):
         raise RuntimeError("Attempted to define {} as both mutable and immutable.".format(func.__name__))
     global_mut_names.add(func.__name__)
     return None
+
+from .core_methods import extern
+

--- a/spark/util/helper_functions/arc_functions.py
+++ b/spark/util/helper_functions/arc_functions.py
@@ -1,5 +1,5 @@
 from math import sin, cos
-from ..decorators import *
+from ..decorators import validate_args, ignite_global
 from numbers import Real
 
 
@@ -7,7 +7,7 @@ from numbers import Real
                [Real, Real, Real, Real, Real],
                [Real, Real, Real, Real, Real, Real],
                [Real, Real, Real, Real, Real, Real, str])
-@global_immut
+@ignite_global
 def helper_fill_arc(self, *args):
     x, y, r, scale_x, scale_y, start, stop, mode = self.arc_args(*args)
 
@@ -37,7 +37,7 @@ def helper_fill_arc(self, *args):
                [Real, Real, Real, Real, Real],
                [Real, Real, Real, Real, Real, Real],
                [Real, Real, Real, Real, Real, Real, str])
-@global_immut
+@ignite_global
 def helper_stroke_arc(self, *args):
     x, y, r, scale_x, scale_y, start, stop, mode = self.arc_args(*args)
 
@@ -70,7 +70,7 @@ def helper_stroke_arc(self, *args):
                [Real, Real, Real, Real, Real],
                [Real, Real, Real, Real, Real, Real],
                [Real, Real, Real, Real, Real, Real, str])
-@global_immut
+@ignite_global
 def helper_arc(self, *args):
     self.fill_arc(*args)
     self.stroke_arc(*args)

--- a/spark/util/helper_functions/arc_functions.py
+++ b/spark/util/helper_functions/arc_functions.py
@@ -1,0 +1,76 @@
+from math import sin, cos
+from ..decorators import *
+from numbers import Real
+
+
+@validate_args([Real, Real, Real, Real],
+               [Real, Real, Real, Real, Real],
+               [Real, Real, Real, Real, Real, Real],
+               [Real, Real, Real, Real, Real, Real, str])
+@global_immut
+def helper_fill_arc(self, *args):
+    x, y, r, scale_x, scale_y, start, stop, mode = self.arc_args(*args)
+
+    if scale_x == 0 or scale_y == 0:
+        return
+
+    self.canvas.translate(x, y)
+    self.canvas.scale(scale_x, scale_y)
+
+    if mode == "open" or mode == "chord":
+        self.canvas.fill_arc(0, 0, r, start, stop)
+    elif mode == "default" or mode == "pie":
+        self.canvas.begin_path()
+        start_x = r*cos(start)
+        start_y = r*sin(start)
+        self.canvas.move_to(start_x, start_y)
+        self.canvas.arc(0, 0, r, start, stop)
+        self.canvas.line_to(0, 0)
+        self.canvas.close_path()
+        self.canvas.fill()
+
+    self.canvas.scale(1/scale_x, 1/scale_y)
+    self.canvas.translate(-x, -y)
+
+
+@validate_args([Real, Real, Real, Real],
+               [Real, Real, Real, Real, Real],
+               [Real, Real, Real, Real, Real, Real],
+               [Real, Real, Real, Real, Real, Real, str])
+@global_immut
+def helper_stroke_arc(self, *args):
+    x, y, r, scale_x, scale_y, start, stop, mode = self.arc_args(*args)
+
+    if scale_x == 0 or scale_y == 0:
+        return
+
+    start_x = r*cos(start)
+    start_y = r*sin(start)
+
+    self.canvas.translate(x, y)
+    self.canvas.scale(scale_x, scale_y)
+
+    self.canvas.begin_path()
+    self.canvas.move_to(start_x, start_y)
+    self.canvas.arc(0, 0, r, start, stop)
+    if mode == "open" or mode == "default":
+        self.canvas.move_to(start_x, start_y)
+    elif mode == "pie":
+        self.canvas.line_to(0, 0)
+    elif mode == "chord":
+        pass
+    self.canvas.close_path()
+    self.canvas.stroke()
+
+    self.canvas.scale(1/scale_x, 1/scale_y)
+    self.canvas.translate(-x, -y)
+
+
+@validate_args([Real, Real, Real, Real],
+               [Real, Real, Real, Real, Real],
+               [Real, Real, Real, Real, Real, Real],
+               [Real, Real, Real, Real, Real, Real, str])
+@global_immut
+def helper_arc(self, *args):
+    self.fill_arc(*args)
+    self.stroke_arc(*args)

--- a/spark/util/helper_functions/canvas_functions.py
+++ b/spark/util/helper_functions/canvas_functions.py
@@ -3,32 +3,32 @@ from ..decorators import *
 
 
 @validate_args([Real, Real])
-@global_immut
+@ignite_global
 def helper_size(self, *args):
     self.width = args[0]
     self.height = args[1]
 
 
 @validate_args([str], [Real], [Real, Real, Real], [Real, Real, Real, Real])
-@global_immut
+@ignite_global
 def helper_fill_style(self, *args):
     self.canvas.fill_style = self.parse_color(func_name="fill_style", *args)
 
 
 @validate_args([str], [Real], [Real, Real, Real], [Real, Real, Real, Real])
-@global_immut
+@ignite_global
 def helper_stroke_style(self, *args):
     self.canvas.stroke_style = self.parse_color(func_name="stroke_style", *args)
 
 
 @validate_args([])
-@global_immut
+@ignite_global
 def helper_clear(self, *args):
     self.canvas.clear()
 
 
 @validate_args([str], [Real], [Real, Real, Real], [Real, Real, Real, Real])
-@global_immut
+@ignite_global
 def helper_background(self, *args):
     fill = self.parse_color(func_name="background", *args)
     old_fill = self.canvas.fill_style

--- a/spark/util/helper_functions/canvas_functions.py
+++ b/spark/util/helper_functions/canvas_functions.py
@@ -1,0 +1,37 @@
+from numbers import Real
+from ..decorators import *
+
+
+@validate_args([Real, Real])
+@global_immut
+def helper_size(self, *args):
+    self.width = args[0]
+    self.height = args[1]
+
+
+@validate_args([str], [Real], [Real, Real, Real], [Real, Real, Real, Real])
+@global_immut
+def helper_fill_style(self, *args):
+    self.canvas.fill_style = self.parse_color(func_name="fill_style", *args)
+
+
+@validate_args([str], [Real], [Real, Real, Real], [Real, Real, Real, Real])
+@global_immut
+def helper_stroke_style(self, *args):
+    self.canvas.stroke_style = self.parse_color(func_name="stroke_style", *args)
+
+
+@validate_args([])
+@global_immut
+def helper_clear(self, *args):
+    self.canvas.clear()
+
+
+@validate_args([str], [Real], [Real, Real, Real], [Real, Real, Real, Real])
+@global_immut
+def helper_background(self, *args):
+    fill = self.parse_color(func_name="background", *args)
+    old_fill = self.canvas.fill_style
+    self.canvas.fill_style = fill
+    self.canvas.fill_rect(0, 0, self.width, self.height)
+    self.canvas.fill_style = old_fill

--- a/spark/util/helper_functions/circle_functions.py
+++ b/spark/util/helper_functions/circle_functions.py
@@ -3,18 +3,18 @@ from numbers import Real
 
 
 @validate_args([Real, Real, Real])
-@global_immut
+@ignite_global
 def helper_circle(self, *args):
     self.ellipse(*args, args[2])
 
 
 @validate_args([Real, Real, Real])
-@global_immut
+@ignite_global
 def helper_stroke_circle(self, *args):
     self.stroke_ellipse(*args, args[2])
 
 
 @validate_args([Real, Real, Real])
-@global_immut
+@ignite_global
 def helper_fill_circle(self, *args):
     self.fill_ellipse(*args, args[2])

--- a/spark/util/helper_functions/circle_functions.py
+++ b/spark/util/helper_functions/circle_functions.py
@@ -1,0 +1,20 @@
+from ..decorators import *
+from numbers import Real
+
+
+@validate_args([Real, Real, Real])
+@global_immut
+def helper_circle(self, *args):
+    self.ellipse(*args, args[2])
+
+
+@validate_args([Real, Real, Real])
+@global_immut
+def helper_stroke_circle(self, *args):
+    self.stroke_ellipse(*args, args[2])
+
+
+@validate_args([Real, Real, Real])
+@global_immut
+def helper_fill_circle(self, *args):
+    self.fill_ellipse(*args, args[2])

--- a/spark/util/helper_functions/ellipse_functions.py
+++ b/spark/util/helper_functions/ellipse_functions.py
@@ -3,19 +3,19 @@ from numbers import Real
 
 
 @validate_args([Real, Real, Real, Real])
-@global_immut
+@ignite_global
 def helper_ellipse(self, *args):
     self.fill_ellipse(*args)
     self.stroke_ellipse(*args)
 
 
 @validate_args([Real, Real, Real, Real])
-@global_immut
+@ignite_global
 def helper_stroke_ellipse(self, *args):
     self.stroke_arc(*args)
 
 
 @validate_args([Real, Real, Real, Real])
-@global_immut
+@ignite_global
 def helper_fill_ellipse(self, *args):
     self.fill_arc(*args)

--- a/spark/util/helper_functions/ellipse_functions.py
+++ b/spark/util/helper_functions/ellipse_functions.py
@@ -1,0 +1,21 @@
+from ..decorators import *
+from numbers import Real
+
+
+@validate_args([Real, Real, Real, Real])
+@global_immut
+def helper_ellipse(self, *args):
+    self.fill_ellipse(*args)
+    self.stroke_ellipse(*args)
+
+
+@validate_args([Real, Real, Real, Real])
+@global_immut
+def helper_stroke_ellipse(self, *args):
+    self.stroke_arc(*args)
+
+
+@validate_args([Real, Real, Real, Real])
+@global_immut
+def helper_fill_ellipse(self, *args):
+    self.fill_arc(*args)

--- a/spark/util/helper_functions/line_functions.py
+++ b/spark/util/helper_functions/line_functions.py
@@ -3,7 +3,7 @@ from numbers import Real
 
 
 @validate_args([Real, Real, Real, Real])
-@global_immut
+@ignite_global
 def helper_draw_line(self, *args):
     self.canvas.begin_path()
     self.canvas.move_to(args[0], args[1])
@@ -13,18 +13,18 @@ def helper_draw_line(self, *args):
 
 
 @validate_args([Real, Real, Real, Real])
-@global_immut
+@ignite_global
 def helper_line(self, *args):
     self.draw_line(*args)
 
 
 @validate_args([Real])
-@global_immut
+@ignite_global
 def helper_line_width(self, *args):
     self.canvas.line_width = args[0]
 
 
 @validate_args([Real])
-@global_immut
+@ignite_global
 def helper_stroke_width(self, *args):
     self.line_width(*args)

--- a/spark/util/helper_functions/line_functions.py
+++ b/spark/util/helper_functions/line_functions.py
@@ -1,0 +1,30 @@
+from ..decorators import *
+from numbers import Real
+
+
+@validate_args([Real, Real, Real, Real])
+@global_immut
+def helper_draw_line(self, *args):
+    self.canvas.begin_path()
+    self.canvas.move_to(args[0], args[1])
+    self.canvas.line_to(args[2], args[3])
+    self.canvas.close_path()
+    self.canvas.stroke()
+
+
+@validate_args([Real, Real, Real, Real])
+@global_immut
+def helper_line(self, *args):
+    self.draw_line(*args)
+
+
+@validate_args([Real])
+@global_immut
+def helper_line_width(self, *args):
+    self.canvas.line_width = args[0]
+
+
+@validate_args([Real])
+@global_immut
+def helper_stroke_width(self, *args):
+    self.line_width(*args)

--- a/spark/util/helper_functions/misc_functions.py
+++ b/spark/util/helper_functions/misc_functions.py
@@ -1,0 +1,85 @@
+from ..decorators import *
+from ..HTMLColors import HTMLColors
+import re
+from ..Errors import *
+from numbers import Real
+from math import pi
+import random
+
+
+@validate_args([str, str])
+def helper_parse_color_string(self, func_name, s):
+    rws = re.compile(r'\s')
+    no_ws = rws.sub('', s).lower()
+    # Check allowed color strings
+    if no_ws in HTMLColors:
+        return no_ws
+    elif no_ws in self.color_strings:
+        return self.color_strings[s]
+    # Check other HTML-permissible formats
+    else:
+        for regex in self.regexes:
+            if regex.fullmatch(no_ws) is not None:
+                return no_ws
+    # Not in any permitted format
+    raise ArgumentConditionError(func_name, "", "Valid HTML format or color names", s)
+
+
+@validate_args([str], [Real], [Real, Real, Real], [Real, Real, Real, Real])
+def helper_parse_color(self, *args, func_name="parse_color"):
+    def clip(x, lb, ub):
+        return min(max(x, lb), ub)
+    argc = len(args)
+
+    if argc == 1:
+        if isinstance(args[0], Real):
+            n = int(clip(args[0], 0, 255))
+            return f"rgb({n}, {n}, {n})"
+        elif isinstance(args[0], str):
+            return self.parse_color_string(func_name, args[0])
+        raise ArgumentConditionError(func_name, "", "Valid HTML format or color names", args[0])
+    elif argc == 3 or argc == 4:
+        color_args = [int(clip(arg, 0, 255)) for arg in args[:3]]
+
+        if argc == 3:
+            return "rgb({}, {}, {})".format(*color_args)
+        else:
+            # Clip alpha between 0 and 1
+            alpha_arg = clip(args[3], 0, 1.0)
+            return "rgba({}, {}, {}, {})".format(*color_args, alpha_arg)
+    else:
+        raise ArgumentNumError(func_name, [1, 3, 4], argc)
+
+
+@validate_args([Real, Real, Real, Real],
+               [Real, Real, Real, Real, Real],
+               [Real, Real, Real, Real, Real, Real],
+               [Real, Real, Real, Real, Real, Real, str])
+def helper_arc_args(self, *args):
+    argc = len(args)
+    x, y, w, h = args[:4]
+    defaults = [0, 2*pi, "default"]
+    start, stop, mode = [*args[4:argc], *defaults[argc-4:]]
+    while start < 0:
+        start += 2*pi
+    while start > 2*pi:
+        start -= 2*pi
+    while stop < 0:
+        stop += 2*pi
+    while stop > 2*pi:
+        stop += 2*pi
+    d = max(w, h)/2
+
+    return x, y, d/2, w/d, h/d, start, stop, mode
+
+
+@validate_args([])
+@global_immut
+def helper_random(self, *args):
+    return random.random()
+
+
+@validate_args([int])
+@global_immut
+def helper_randint(self, *args):
+    return random.randint(0, args[0])

--- a/spark/util/helper_functions/misc_functions.py
+++ b/spark/util/helper_functions/misc_functions.py
@@ -74,12 +74,12 @@ def helper_arc_args(self, *args):
 
 
 @validate_args([])
-@global_immut
+@ignite_global
 def helper_random(self, *args):
     return random.random()
 
 
 @validate_args([int])
-@global_immut
+@ignite_global
 def helper_randint(self, *args):
     return random.randint(0, args[0])

--- a/spark/util/helper_functions/rect_functions.py
+++ b/spark/util/helper_functions/rect_functions.py
@@ -1,0 +1,27 @@
+from ..decorators import *
+from numbers import Real
+
+
+@validate_args([Real, Real, Real, Real])
+@global_immut
+def helper_rect(self, *args):
+    self.canvas.fill_rect(*args)
+    self.canvas.stroke_rect(*args)
+
+
+@validate_args([Real, Real, Real, Real])
+@global_immut
+def helper_fill_rect(self, *args):
+    self.canvas.fill_rect(*args)
+
+
+@validate_args([Real, Real, Real, Real])
+@global_immut
+def helper_stroke_rect(self, *args):
+    self.canvas.stroke_rect(*args)
+
+
+@validate_args([Real, Real, Real, Real])
+@global_immut
+def helper_clear_rect(self, *args):
+    self.canvas.clear_rect(*args)

--- a/spark/util/helper_functions/rect_functions.py
+++ b/spark/util/helper_functions/rect_functions.py
@@ -3,25 +3,25 @@ from numbers import Real
 
 
 @validate_args([Real, Real, Real, Real])
-@global_immut
+@ignite_global
 def helper_rect(self, *args):
     self.canvas.fill_rect(*args)
     self.canvas.stroke_rect(*args)
 
 
 @validate_args([Real, Real, Real, Real])
-@global_immut
+@ignite_global
 def helper_fill_rect(self, *args):
     self.canvas.fill_rect(*args)
 
 
 @validate_args([Real, Real, Real, Real])
-@global_immut
+@ignite_global
 def helper_stroke_rect(self, *args):
     self.canvas.stroke_rect(*args)
 
 
 @validate_args([Real, Real, Real, Real])
-@global_immut
+@ignite_global
 def helper_clear_rect(self, *args):
     self.canvas.clear_rect(*args)

--- a/spark/util/helper_functions/square_functions.py
+++ b/spark/util/helper_functions/square_functions.py
@@ -1,0 +1,20 @@
+from ..decorators import *
+from numbers import Real
+
+
+@validate_args([Real, Real, Real])
+@global_immut
+def helper_square(self, *args):
+    self.rect(*args, args[2])
+
+
+@validate_args([Real, Real, Real])
+@global_immut
+def helper_stroke_square(self, *args):
+    self.stroke_rect(*args, args[2])
+
+
+@validate_args([Real, Real, Real])
+@global_immut
+def helper_fill_square(self, *args):
+    self.fill_rect(*args, args[2])

--- a/spark/util/helper_functions/square_functions.py
+++ b/spark/util/helper_functions/square_functions.py
@@ -3,18 +3,18 @@ from numbers import Real
 
 
 @validate_args([Real, Real, Real])
-@global_immut
+@ignite_global
 def helper_square(self, *args):
     self.rect(*args, args[2])
 
 
 @validate_args([Real, Real, Real])
-@global_immut
+@ignite_global
 def helper_stroke_square(self, *args):
     self.stroke_rect(*args, args[2])
 
 
 @validate_args([Real, Real, Real])
-@global_immut
+@ignite_global
 def helper_fill_square(self, *args):
     self.fill_rect(*args, args[2])

--- a/spark/util/helper_functions/text_functions.py
+++ b/spark/util/helper_functions/text_functions.py
@@ -1,0 +1,30 @@
+from ..decorators import *
+from ..Errors import *
+from numbers import Real
+
+
+@validate_args([int])
+@global_immut
+def helper_text_size(self, *args):
+    self.font_settings['size'] = args[0]
+    self.canvas.font = f"{self.font_settings['size']}px {self.font_settings['font']}"
+
+
+@validate_args([str])
+@global_immut
+def helper_text_align(self, *args):
+    if args[0] not in ['left', 'right', 'center']:
+        raise ArgumentConditionError("text_align", None, '"left", "right", or "center"', args[0])
+
+    self.canvas.text_align = args[0]
+
+
+@validate_args([object, Real, Real])
+@global_immut
+def helper_text(self, *args):
+    # Reassigning the properties gets around a bug with the properties not being used.
+    self.canvas.font = self.canvas.font
+    self.canvas.text_baseline = self.canvas.text_baseline
+    self.canvas.text_align = self.canvas.text_align
+
+    self.canvas.fill_text(str(args[0]), args[1], args[2])

--- a/spark/util/helper_functions/text_functions.py
+++ b/spark/util/helper_functions/text_functions.py
@@ -4,14 +4,14 @@ from numbers import Real
 
 
 @validate_args([int])
-@global_immut
+@ignite_global
 def helper_text_size(self, *args):
     self.font_settings['size'] = args[0]
     self.canvas.font = f"{self.font_settings['size']}px {self.font_settings['font']}"
 
 
 @validate_args([str])
-@global_immut
+@ignite_global
 def helper_text_align(self, *args):
     if args[0] not in ['left', 'right', 'center']:
         raise ArgumentConditionError("text_align", None, '"left", "right", or "center"', args[0])
@@ -20,7 +20,7 @@ def helper_text_align(self, *args):
 
 
 @validate_args([object, Real, Real])
-@global_immut
+@ignite_global
 def helper_text(self, *args):
     # Reassigning the properties gets around a bug with the properties not being used.
     self.canvas.font = self.canvas.font

--- a/spark/util/helper_functions/triangle_functions.py
+++ b/spark/util/helper_functions/triangle_functions.py
@@ -1,0 +1,31 @@
+from ..decorators import *
+from numbers import Real
+
+
+@validate_args([Real, Real, Real, Real, Real, Real])
+@global_immut
+def helper_triangle(self, *args):
+    self.fill_triangle(*args)
+    self.stroke_triangle(*args)
+
+
+@validate_args([Real, Real, Real, Real, Real, Real])
+@global_immut
+def helper_stroke_triangle(self, *args):
+    self.canvas.begin_path()
+    self.canvas.move_to(args[0], args[1])
+    self.canvas.line_to(args[2], args[3])
+    self.canvas.line_to(args[4], args[5])
+    self.canvas.close_path()
+    self.canvas.stroke()
+
+
+@validate_args([Real, Real, Real, Real, Real, Real])
+@global_immut
+def helper_fill_triangle(self, *args):
+    self.canvas.begin_path()
+    self.canvas.move_to(args[0], args[1])
+    self.canvas.line_to(args[2], args[3])
+    self.canvas.line_to(args[4], args[5])
+    self.canvas.close_path()
+    self.canvas.fill()

--- a/spark/util/helper_functions/triangle_functions.py
+++ b/spark/util/helper_functions/triangle_functions.py
@@ -3,14 +3,14 @@ from numbers import Real
 
 
 @validate_args([Real, Real, Real, Real, Real, Real])
-@global_immut
+@ignite_global
 def helper_triangle(self, *args):
     self.fill_triangle(*args)
     self.stroke_triangle(*args)
 
 
 @validate_args([Real, Real, Real, Real, Real, Real])
-@global_immut
+@ignite_global
 def helper_stroke_triangle(self, *args):
     self.canvas.begin_path()
     self.canvas.move_to(args[0], args[1])
@@ -21,7 +21,7 @@ def helper_stroke_triangle(self, *args):
 
 
 @validate_args([Real, Real, Real, Real, Real, Real])
-@global_immut
+@ignite_global
 def helper_fill_triangle(self, *args):
     self.canvas.begin_path()
     self.canvas.move_to(args[0], args[1])

--- a/test/Background Function Test.ipynb
+++ b/test/Background Function Test.ipynb
@@ -109,7 +109,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "77d89e6cbe044439b736b66890bf0f67",
+       "model_id": "4fb7ebe6c5814b36aa57be3cd9d47b57",
        "version_major": 2,
        "version_minor": 0
       },
@@ -319,7 +319,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "abf1efab5a3c44999ea9d18a0e7f72d0",
+       "model_id": "143b41762ddf42a9ba9f8dd9c5a3d2b2",
        "version_major": 2,
        "version_minor": 0
       },
@@ -528,7 +528,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d7f853d1db984005bc8ea375354a0db6",
+       "model_id": "ffd1f740414d487e93e1cf152ec44758",
        "version_major": 2,
        "version_minor": 0
       },
@@ -737,7 +737,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9b42ac57044a4384a778e1f4a6127160",
+       "model_id": "eb286ac92aac485fbc9bd64f4c036f26",
        "version_major": 2,
        "version_minor": 0
       },
@@ -946,7 +946,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "66d19d2593594a2f9f4bc6e11007febe",
+       "model_id": "afdae599a9354f1c928470fc74f8cfbf",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1155,7 +1155,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0af7deffa9d84ec8b78b8966ec77b129",
+       "model_id": "6ba027cb609d4673b144e00ca90d9bba",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1364,7 +1364,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "88b3526008b7484ea7cb39675933cb23",
+       "model_id": "309201633dc64675a223dd2a8cc0a332",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1573,7 +1573,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "678b046989894eceba8ccd89371d164c",
+       "model_id": "0c27baeb986d4eb1a41c4016242b8b32",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1782,7 +1782,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "db2d7271b9824176991e2460bde00aa6",
+       "model_id": "3cb5d91eefc64078a5f71e85265ad8a9",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1991,7 +1991,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8d0d19e3785b4b3cac073e725c190565",
+       "model_id": "8a9d8abb6b9e4678a2af198a9fe908c4",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2109,7 +2109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -2206,7 +2206,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e24d5faf19bb430f8008c778681f2602",
+       "model_id": "4872951e9bdb443598f886dd3a380660",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2220,7 +2220,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b77bbb76dc634ea793188223f069d987",
+       "model_id": "9a05d62485b84a06bbb108462599847e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2434,7 +2434,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1acb87ad975a4c1e8ddc586ead2d867f",
+       "model_id": "55cde440b34e4ab7becff2f8763d0df5",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2643,7 +2643,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "03e1ce76ce5a42e0aa2bd2f376cf6cdf",
+       "model_id": "fdc5faa3b96a40129ec11a3a3c9b90fc",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2852,7 +2852,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e842dfd6ccc24eafb45da7b0a0a81790",
+       "model_id": "637e753e4d50426aa74193e48e0042cc",
        "version_major": 2,
        "version_minor": 0
       },
@@ -3061,7 +3061,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "35fa0556549540478379f056d66482c7",
+       "model_id": "5eeeefa40d7943bf9d17663faf27b05d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -3252,16 +3252,16 @@
        ".output_html .vg { color: #19177C } /* Name.Variable.Global */\n",
        ".output_html .vi { color: #19177C } /* Name.Variable.Instance */\n",
        ".output_html .vm { color: #19177C } /* Name.Variable.Magic */\n",
-       ".output_html .il { color: #666666 } /* Literal.Number.Integer.Long */</style><div class=\"highlight\"><pre><span></span><span class=\"err\">Stopped</span>\n",
+       ".output_html .il { color: #666666 } /* Literal.Number.Integer.Long */</style><div class=\"highlight\"><pre><span></span><span class=\"err\">Done drawing</span>\n",
        "</pre></div>\n"
       ],
       "text/latex": [
        "\\begin{Verbatim}[commandchars=\\\\\\{\\}]\n",
-       "\\PY{err}{S}\\PY{err}{t}\\PY{err}{o}\\PY{err}{p}\\PY{err}{p}\\PY{err}{e}\\PY{err}{d}\n",
+       "\\PY{err}{D}\\PY{err}{o}\\PY{err}{n}\\PY{err}{e}\\PY{err}{ }\\PY{err}{d}\\PY{err}{r}\\PY{err}{a}\\PY{err}{w}\\PY{err}{i}\\PY{err}{n}\\PY{err}{g}\n",
        "\\end{Verbatim}\n"
       ],
       "text/plain": [
-       "Stopped"
+       "Done drawing"
       ]
      },
      "metadata": {},
@@ -3270,7 +3270,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7095e8492b2d446ea5007ee141fe0455",
+       "model_id": "c9ea62b90d824b05976bacd34a20f94b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -3385,6 +3385,13 @@
     "    if canvas.fill_style != 'red':\n",
     "        raise Exception(\"Expected old fill_style to be restored at 'red', instead got {}\".format(canvas.fill_style))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",

--- a/test/Background Function Test.ipynb
+++ b/test/Background Function Test.ipynb
@@ -109,7 +109,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7e16e86087d742c8bd47ff031eaa2d2b",
+       "model_id": "77d89e6cbe044439b736b66890bf0f67",
        "version_major": 2,
        "version_minor": 0
       },
@@ -319,7 +319,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b8aae27a67be4c8c9d31943bdc67cf5e",
+       "model_id": "abf1efab5a3c44999ea9d18a0e7f72d0",
        "version_major": 2,
        "version_minor": 0
       },
@@ -528,7 +528,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "791f67e6b7c44b70a39647de31fc0d62",
+       "model_id": "d7f853d1db984005bc8ea375354a0db6",
        "version_major": 2,
        "version_minor": 0
       },
@@ -737,7 +737,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8f5dd6b873254302a68dd2fd25e2f671",
+       "model_id": "9b42ac57044a4384a778e1f4a6127160",
        "version_major": 2,
        "version_minor": 0
       },
@@ -946,7 +946,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7a032b2238544292a5b434b90e2a7762",
+       "model_id": "66d19d2593594a2f9f4bc6e11007febe",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1155,7 +1155,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "652b306ebb8448c599852e65976330f2",
+       "model_id": "0af7deffa9d84ec8b78b8966ec77b129",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1364,7 +1364,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "32ad73c45ae34a178f11ca62687feeeb",
+       "model_id": "88b3526008b7484ea7cb39675933cb23",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1573,7 +1573,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ec860b2a8f3e49bb928dcb0ed916eb9a",
+       "model_id": "678b046989894eceba8ccd89371d164c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1782,7 +1782,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bd5a0d2665d7430fad7b75cc62186e22",
+       "model_id": "db2d7271b9824176991e2460bde00aa6",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1991,7 +1991,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "410e878bfa0343019d5fae6588dcc0e0",
+       "model_id": "8d0d19e3785b4b3cac073e725c190565",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2109,7 +2109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -2206,7 +2206,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "73d40176c32d4531ab292b8b46c3e077",
+       "model_id": "e24d5faf19bb430f8008c778681f2602",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2220,7 +2220,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "40b12375b8fb4da1a799e2702dfd6b25",
+       "model_id": "b77bbb76dc634ea793188223f069d987",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2434,7 +2434,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4b7607687acd4f4aa52ad1226c3e04fd",
+       "model_id": "1acb87ad975a4c1e8ddc586ead2d867f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2643,7 +2643,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ae5be9280ccc488bb34fda81bca58b11",
+       "model_id": "03e1ce76ce5a42e0aa2bd2f376cf6cdf",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2852,7 +2852,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8f35f194d1b34e47ad8b8e7d02669689",
+       "model_id": "e842dfd6ccc24eafb45da7b0a0a81790",
        "version_major": 2,
        "version_minor": 0
       },
@@ -3061,7 +3061,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5dd55ed5a49d459db027bcc07248492b",
+       "model_id": "35fa0556549540478379f056d66482c7",
        "version_major": 2,
        "version_minor": 0
       },
@@ -3252,16 +3252,16 @@
        ".output_html .vg { color: #19177C } /* Name.Variable.Global */\n",
        ".output_html .vi { color: #19177C } /* Name.Variable.Instance */\n",
        ".output_html .vm { color: #19177C } /* Name.Variable.Magic */\n",
-       ".output_html .il { color: #666666 } /* Literal.Number.Integer.Long */</style><div class=\"highlight\"><pre><span></span><span class=\"err\">Done drawing</span>\n",
+       ".output_html .il { color: #666666 } /* Literal.Number.Integer.Long */</style><div class=\"highlight\"><pre><span></span><span class=\"err\">Stopped</span>\n",
        "</pre></div>\n"
       ],
       "text/latex": [
        "\\begin{Verbatim}[commandchars=\\\\\\{\\}]\n",
-       "\\PY{err}{D}\\PY{err}{o}\\PY{err}{n}\\PY{err}{e}\\PY{err}{ }\\PY{err}{d}\\PY{err}{r}\\PY{err}{a}\\PY{err}{w}\\PY{err}{i}\\PY{err}{n}\\PY{err}{g}\n",
+       "\\PY{err}{S}\\PY{err}{t}\\PY{err}{o}\\PY{err}{p}\\PY{err}{p}\\PY{err}{e}\\PY{err}{d}\n",
        "\\end{Verbatim}\n"
       ],
       "text/plain": [
-       "Done drawing"
+       "Stopped"
       ]
      },
      "metadata": {},
@@ -3270,7 +3270,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "80d601bcc1204371b761d44743778bf5",
+       "model_id": "7095e8492b2d446ea5007ee141fe0455",
        "version_major": 2,
        "version_minor": 0
       },
@@ -3410,7 +3410,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/test/CanvasTest.ipynb
+++ b/test/CanvasTest.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -109,7 +109,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "875561422e7c42f09c15f234a506eb84",
+       "model_id": "88568c07789642b984260284c947a821",
        "version_major": 2,
        "version_minor": 0
       },
@@ -123,7 +123,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2bbfc75f96b64501b737ee20f2bd4c13",
+       "model_id": "0fe6d72b80464f478514d869eff61c25",
        "version_major": 2,
        "version_minor": 0
       },
@@ -260,7 +260,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/test/CanvasTest.ipynb
+++ b/test/CanvasTest.ipynb
@@ -109,7 +109,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "88568c07789642b984260284c947a821",
+       "model_id": "ea32f703a8c84305b03178af17415a98",
        "version_major": 2,
        "version_minor": 0
       },
@@ -123,7 +123,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0fe6d72b80464f478514d869eff61c25",
+       "model_id": "414342fcc62d46a6a60b73236a970288",
        "version_major": 2,
        "version_minor": 0
       },

--- a/test/EllipseAndArcTest.ipynb
+++ b/test/EllipseAndArcTest.ipynb
@@ -109,7 +109,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c4bba79d960048b38206c5ed7fc5b6b9",
+       "model_id": "ea694fd796754ed9bf1caa328a4abd1f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -123,7 +123,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "de8db1169a9746178a7c20ce1e8e317c",
+       "model_id": "575f64dd9c0a411caccf154bfa416258",
        "version_major": 2,
        "version_minor": 0
       },

--- a/test/EllipseAndArcTest.ipynb
+++ b/test/EllipseAndArcTest.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -109,7 +109,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c1b5c75a44324781887a5540595f1640",
+       "model_id": "c4bba79d960048b38206c5ed7fc5b6b9",
        "version_major": 2,
        "version_minor": 0
       },
@@ -123,7 +123,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "21606b0a392b434680af2ac5de79de9a",
+       "model_id": "de8db1169a9746178a7c20ce1e8e317c",
        "version_major": 2,
        "version_minor": 0
       },

--- a/test/FillStyleTest.ipynb
+++ b/test/FillStyleTest.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -109,7 +109,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "94e01d87877143fbaa7dd27a66f3128c",
+       "model_id": "fe112637ecd64288a17c44da47385a4f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -197,39 +197,15 @@
        ".output_html .vi { color: #19177C } /* Name.Variable.Instance */\n",
        ".output_html .vm { color: #19177C } /* Name.Variable.Magic */\n",
        ".output_html .il { color: #666666 } /* Literal.Number.Integer.Long */</style><div class=\"highlight\"><pre><span></span><span class=\"err\">fill_style renders fill color </span>\n",
-       "<span class=\"err\">with string input</span>\n",
-       "<span class=\"err\">with rgb in bounds</span>\n",
-       "<span class=\"err\">with rgb out of bounds</span>\n",
-       "<span class=\"err\">with rgba in bounds</span>\n",
-       "<span class=\"err\">with rgba out of bounds</span>\n",
-       "<span class=\"err\">with one int gives grey</span>\n",
-       "<span class=\"err\">with one float gives grey</span>\n",
-       "<span class=\"err\">rgb with floats in bounds</span>\n",
        "</pre></div>\n"
       ],
       "text/latex": [
        "\\begin{Verbatim}[commandchars=\\\\\\{\\}]\n",
        "\\PY{err}{f}\\PY{err}{i}\\PY{err}{l}\\PY{err}{l}\\PY{err}{\\PYZus{}}\\PY{err}{s}\\PY{err}{t}\\PY{err}{y}\\PY{err}{l}\\PY{err}{e}\\PY{err}{ }\\PY{err}{r}\\PY{err}{e}\\PY{err}{n}\\PY{err}{d}\\PY{err}{e}\\PY{err}{r}\\PY{err}{s}\\PY{err}{ }\\PY{err}{f}\\PY{err}{i}\\PY{err}{l}\\PY{err}{l}\\PY{err}{ }\\PY{err}{c}\\PY{err}{o}\\PY{err}{l}\\PY{err}{o}\\PY{err}{r}\\PY{err}{ }\n",
-       "\\PY{err}{w}\\PY{err}{i}\\PY{err}{t}\\PY{err}{h}\\PY{err}{ }\\PY{err}{s}\\PY{err}{t}\\PY{err}{r}\\PY{err}{i}\\PY{err}{n}\\PY{err}{g}\\PY{err}{ }\\PY{err}{i}\\PY{err}{n}\\PY{err}{p}\\PY{err}{u}\\PY{err}{t}\n",
-       "\\PY{err}{w}\\PY{err}{i}\\PY{err}{t}\\PY{err}{h}\\PY{err}{ }\\PY{err}{r}\\PY{err}{g}\\PY{err}{b}\\PY{err}{ }\\PY{err}{i}\\PY{err}{n}\\PY{err}{ }\\PY{err}{b}\\PY{err}{o}\\PY{err}{u}\\PY{err}{n}\\PY{err}{d}\\PY{err}{s}\n",
-       "\\PY{err}{w}\\PY{err}{i}\\PY{err}{t}\\PY{err}{h}\\PY{err}{ }\\PY{err}{r}\\PY{err}{g}\\PY{err}{b}\\PY{err}{ }\\PY{err}{o}\\PY{err}{u}\\PY{err}{t}\\PY{err}{ }\\PY{err}{o}\\PY{err}{f}\\PY{err}{ }\\PY{err}{b}\\PY{err}{o}\\PY{err}{u}\\PY{err}{n}\\PY{err}{d}\\PY{err}{s}\n",
-       "\\PY{err}{w}\\PY{err}{i}\\PY{err}{t}\\PY{err}{h}\\PY{err}{ }\\PY{err}{r}\\PY{err}{g}\\PY{err}{b}\\PY{err}{a}\\PY{err}{ }\\PY{err}{i}\\PY{err}{n}\\PY{err}{ }\\PY{err}{b}\\PY{err}{o}\\PY{err}{u}\\PY{err}{n}\\PY{err}{d}\\PY{err}{s}\n",
-       "\\PY{err}{w}\\PY{err}{i}\\PY{err}{t}\\PY{err}{h}\\PY{err}{ }\\PY{err}{r}\\PY{err}{g}\\PY{err}{b}\\PY{err}{a}\\PY{err}{ }\\PY{err}{o}\\PY{err}{u}\\PY{err}{t}\\PY{err}{ }\\PY{err}{o}\\PY{err}{f}\\PY{err}{ }\\PY{err}{b}\\PY{err}{o}\\PY{err}{u}\\PY{err}{n}\\PY{err}{d}\\PY{err}{s}\n",
-       "\\PY{err}{w}\\PY{err}{i}\\PY{err}{t}\\PY{err}{h}\\PY{err}{ }\\PY{err}{o}\\PY{err}{n}\\PY{err}{e}\\PY{err}{ }\\PY{err}{i}\\PY{err}{n}\\PY{err}{t}\\PY{err}{ }\\PY{err}{g}\\PY{err}{i}\\PY{err}{v}\\PY{err}{e}\\PY{err}{s}\\PY{err}{ }\\PY{err}{g}\\PY{err}{r}\\PY{err}{e}\\PY{err}{y}\n",
-       "\\PY{err}{w}\\PY{err}{i}\\PY{err}{t}\\PY{err}{h}\\PY{err}{ }\\PY{err}{o}\\PY{err}{n}\\PY{err}{e}\\PY{err}{ }\\PY{err}{f}\\PY{err}{l}\\PY{err}{o}\\PY{err}{a}\\PY{err}{t}\\PY{err}{ }\\PY{err}{g}\\PY{err}{i}\\PY{err}{v}\\PY{err}{e}\\PY{err}{s}\\PY{err}{ }\\PY{err}{g}\\PY{err}{r}\\PY{err}{e}\\PY{err}{y}\n",
-       "\\PY{err}{r}\\PY{err}{g}\\PY{err}{b}\\PY{err}{ }\\PY{err}{w}\\PY{err}{i}\\PY{err}{t}\\PY{err}{h}\\PY{err}{ }\\PY{err}{f}\\PY{err}{l}\\PY{err}{o}\\PY{err}{a}\\PY{err}{t}\\PY{err}{s}\\PY{err}{ }\\PY{err}{i}\\PY{err}{n}\\PY{err}{ }\\PY{err}{b}\\PY{err}{o}\\PY{err}{u}\\PY{err}{n}\\PY{err}{d}\\PY{err}{s}\n",
        "\\end{Verbatim}\n"
       ],
       "text/plain": [
-       "fill_style renders fill color \n",
-       "with string input\n",
-       "with rgb in bounds\n",
-       "with rgb out of bounds\n",
-       "with rgba in bounds\n",
-       "with rgba out of bounds\n",
-       "with one int gives grey\n",
-       "with one float gives grey\n",
-       "rgb with floats in bounds"
+       "fill_style renders fill color "
       ]
      },
      "metadata": {},
@@ -316,14 +292,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -420,7 +389,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "04b09bae9a0a45d1857613aed4280c69",
+       "model_id": "1659497871ec46959315e720e1c0484b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -508,27 +477,15 @@
        ".output_html .vi { color: #19177C } /* Name.Variable.Instance */\n",
        ".output_html .vm { color: #19177C } /* Name.Variable.Magic */\n",
        ".output_html .il { color: #666666 } /* Literal.Number.Integer.Long */</style><div class=\"highlight\"><pre><span></span><span class=\"err\">fill_style throws exceptions</span>\n",
-       "<span class=\"err\">with missing args</span>\n",
-       "<span class=\"err\">with None-types in rgba</span>\n",
-       "<span class=\"err\">with string in rgb</span>\n",
-       "<span class=\"err\">with None in string</span>\n",
        "</pre></div>\n"
       ],
       "text/latex": [
        "\\begin{Verbatim}[commandchars=\\\\\\{\\}]\n",
        "\\PY{err}{f}\\PY{err}{i}\\PY{err}{l}\\PY{err}{l}\\PY{err}{\\PYZus{}}\\PY{err}{s}\\PY{err}{t}\\PY{err}{y}\\PY{err}{l}\\PY{err}{e}\\PY{err}{ }\\PY{err}{t}\\PY{err}{h}\\PY{err}{r}\\PY{err}{o}\\PY{err}{w}\\PY{err}{s}\\PY{err}{ }\\PY{err}{e}\\PY{err}{x}\\PY{err}{c}\\PY{err}{e}\\PY{err}{p}\\PY{err}{t}\\PY{err}{i}\\PY{err}{o}\\PY{err}{n}\\PY{err}{s}\n",
-       "\\PY{err}{w}\\PY{err}{i}\\PY{err}{t}\\PY{err}{h}\\PY{err}{ }\\PY{err}{m}\\PY{err}{i}\\PY{err}{s}\\PY{err}{s}\\PY{err}{i}\\PY{err}{n}\\PY{err}{g}\\PY{err}{ }\\PY{err}{a}\\PY{err}{r}\\PY{err}{g}\\PY{err}{s}\n",
-       "\\PY{err}{w}\\PY{err}{i}\\PY{err}{t}\\PY{err}{h}\\PY{err}{ }\\PY{err}{N}\\PY{err}{o}\\PY{err}{n}\\PY{err}{e}\\PY{err}{\\PYZhy{}}\\PY{err}{t}\\PY{err}{y}\\PY{err}{p}\\PY{err}{e}\\PY{err}{s}\\PY{err}{ }\\PY{err}{i}\\PY{err}{n}\\PY{err}{ }\\PY{err}{r}\\PY{err}{g}\\PY{err}{b}\\PY{err}{a}\n",
-       "\\PY{err}{w}\\PY{err}{i}\\PY{err}{t}\\PY{err}{h}\\PY{err}{ }\\PY{err}{s}\\PY{err}{t}\\PY{err}{r}\\PY{err}{i}\\PY{err}{n}\\PY{err}{g}\\PY{err}{ }\\PY{err}{i}\\PY{err}{n}\\PY{err}{ }\\PY{err}{r}\\PY{err}{g}\\PY{err}{b}\n",
-       "\\PY{err}{w}\\PY{err}{i}\\PY{err}{t}\\PY{err}{h}\\PY{err}{ }\\PY{err}{N}\\PY{err}{o}\\PY{err}{n}\\PY{err}{e}\\PY{err}{ }\\PY{err}{i}\\PY{err}{n}\\PY{err}{ }\\PY{err}{s}\\PY{err}{t}\\PY{err}{r}\\PY{err}{i}\\PY{err}{n}\\PY{err}{g}\n",
        "\\end{Verbatim}\n"
       ],
       "text/plain": [
-       "fill_style throws exceptions\n",
-       "with missing args\n",
-       "with None-types in rgba\n",
-       "with string in rgb\n",
-       "with None in string"
+       "fill_style throws exceptions"
       ]
      },
      "metadata": {},
@@ -585,7 +542,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -682,7 +639,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0cc86ddddf194c5a98befc69a906d9a2",
+       "model_id": "b873176f6780459d88b6bedd15d99007",
        "version_major": 2,
        "version_minor": 0
       },
@@ -771,35 +728,17 @@
        ".output_html .vm { color: #19177C } /* Name.Variable.Magic */\n",
        ".output_html .il { color: #666666 } /* Literal.Number.Integer.Long */</style><div class=\"highlight\"><pre><span></span><span class=\"err\">fill_style renders fill color </span>\n",
        "<span class=\"err\">with HTML named color</span>\n",
-       "<span class=\"err\">with custom named string</span>\n",
-       "<span class=\"err\">with hex code string</span>\n",
-       "<span class=\"err\">with rgb command string</span>\n",
-       "<span class=\"err\">with rgba command string</span>\n",
-       "<span class=\"err\">with hsl command string</span>\n",
-       "<span class=\"err\">with hsla command string</span>\n",
        "</pre></div>\n"
       ],
       "text/latex": [
        "\\begin{Verbatim}[commandchars=\\\\\\{\\}]\n",
        "\\PY{err}{f}\\PY{err}{i}\\PY{err}{l}\\PY{err}{l}\\PY{err}{\\PYZus{}}\\PY{err}{s}\\PY{err}{t}\\PY{err}{y}\\PY{err}{l}\\PY{err}{e}\\PY{err}{ }\\PY{err}{r}\\PY{err}{e}\\PY{err}{n}\\PY{err}{d}\\PY{err}{e}\\PY{err}{r}\\PY{err}{s}\\PY{err}{ }\\PY{err}{f}\\PY{err}{i}\\PY{err}{l}\\PY{err}{l}\\PY{err}{ }\\PY{err}{c}\\PY{err}{o}\\PY{err}{l}\\PY{err}{o}\\PY{err}{r}\\PY{err}{ }\n",
        "\\PY{err}{w}\\PY{err}{i}\\PY{err}{t}\\PY{err}{h}\\PY{err}{ }\\PY{err}{H}\\PY{err}{T}\\PY{err}{M}\\PY{err}{L}\\PY{err}{ }\\PY{err}{n}\\PY{err}{a}\\PY{err}{m}\\PY{err}{e}\\PY{err}{d}\\PY{err}{ }\\PY{err}{c}\\PY{err}{o}\\PY{err}{l}\\PY{err}{o}\\PY{err}{r}\n",
-       "\\PY{err}{w}\\PY{err}{i}\\PY{err}{t}\\PY{err}{h}\\PY{err}{ }\\PY{err}{c}\\PY{err}{u}\\PY{err}{s}\\PY{err}{t}\\PY{err}{o}\\PY{err}{m}\\PY{err}{ }\\PY{err}{n}\\PY{err}{a}\\PY{err}{m}\\PY{err}{e}\\PY{err}{d}\\PY{err}{ }\\PY{err}{s}\\PY{err}{t}\\PY{err}{r}\\PY{err}{i}\\PY{err}{n}\\PY{err}{g}\n",
-       "\\PY{err}{w}\\PY{err}{i}\\PY{err}{t}\\PY{err}{h}\\PY{err}{ }\\PY{err}{h}\\PY{err}{e}\\PY{err}{x}\\PY{err}{ }\\PY{err}{c}\\PY{err}{o}\\PY{err}{d}\\PY{err}{e}\\PY{err}{ }\\PY{err}{s}\\PY{err}{t}\\PY{err}{r}\\PY{err}{i}\\PY{err}{n}\\PY{err}{g}\n",
-       "\\PY{err}{w}\\PY{err}{i}\\PY{err}{t}\\PY{err}{h}\\PY{err}{ }\\PY{err}{r}\\PY{err}{g}\\PY{err}{b}\\PY{err}{ }\\PY{err}{c}\\PY{err}{o}\\PY{err}{m}\\PY{err}{m}\\PY{err}{a}\\PY{err}{n}\\PY{err}{d}\\PY{err}{ }\\PY{err}{s}\\PY{err}{t}\\PY{err}{r}\\PY{err}{i}\\PY{err}{n}\\PY{err}{g}\n",
-       "\\PY{err}{w}\\PY{err}{i}\\PY{err}{t}\\PY{err}{h}\\PY{err}{ }\\PY{err}{r}\\PY{err}{g}\\PY{err}{b}\\PY{err}{a}\\PY{err}{ }\\PY{err}{c}\\PY{err}{o}\\PY{err}{m}\\PY{err}{m}\\PY{err}{a}\\PY{err}{n}\\PY{err}{d}\\PY{err}{ }\\PY{err}{s}\\PY{err}{t}\\PY{err}{r}\\PY{err}{i}\\PY{err}{n}\\PY{err}{g}\n",
-       "\\PY{err}{w}\\PY{err}{i}\\PY{err}{t}\\PY{err}{h}\\PY{err}{ }\\PY{err}{h}\\PY{err}{s}\\PY{err}{l}\\PY{err}{ }\\PY{err}{c}\\PY{err}{o}\\PY{err}{m}\\PY{err}{m}\\PY{err}{a}\\PY{err}{n}\\PY{err}{d}\\PY{err}{ }\\PY{err}{s}\\PY{err}{t}\\PY{err}{r}\\PY{err}{i}\\PY{err}{n}\\PY{err}{g}\n",
-       "\\PY{err}{w}\\PY{err}{i}\\PY{err}{t}\\PY{err}{h}\\PY{err}{ }\\PY{err}{h}\\PY{err}{s}\\PY{err}{l}\\PY{err}{a}\\PY{err}{ }\\PY{err}{c}\\PY{err}{o}\\PY{err}{m}\\PY{err}{m}\\PY{err}{a}\\PY{err}{n}\\PY{err}{d}\\PY{err}{ }\\PY{err}{s}\\PY{err}{t}\\PY{err}{r}\\PY{err}{i}\\PY{err}{n}\\PY{err}{g}\n",
        "\\end{Verbatim}\n"
       ],
       "text/plain": [
        "fill_style renders fill color \n",
-       "with HTML named color\n",
-       "with custom named string\n",
-       "with hex code string\n",
-       "with rgb command string\n",
-       "with rgba command string\n",
-       "with hsl command string\n",
-       "with hsla command string"
+       "with HTML named color"
       ]
      },
      "metadata": {},
@@ -883,7 +822,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -980,7 +919,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c474f1e422694475a110083c1b793196",
+       "model_id": "16a77ec1f8b145bc9dba79ca35234a80",
        "version_major": 2,
        "version_minor": 0
       },

--- a/test/FillStyleTest.ipynb
+++ b/test/FillStyleTest.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -109,7 +109,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "43d46cb8fbe84f00a819527042d89bce",
+       "model_id": "94e01d87877143fbaa7dd27a66f3128c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -323,7 +323,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -420,7 +420,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bb476ad87ba345c19e6faeef0a6b102e",
+       "model_id": "04b09bae9a0a45d1857613aed4280c69",
        "version_major": 2,
        "version_minor": 0
       },
@@ -585,7 +585,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -682,7 +682,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "dcd52050f1f34bd0b06617971d1603a6",
+       "model_id": "0cc86ddddf194c5a98befc69a906d9a2",
        "version_major": 2,
        "version_minor": 0
       },
@@ -771,15 +771,35 @@
        ".output_html .vm { color: #19177C } /* Name.Variable.Magic */\n",
        ".output_html .il { color: #666666 } /* Literal.Number.Integer.Long */</style><div class=\"highlight\"><pre><span></span><span class=\"err\">fill_style renders fill color </span>\n",
        "<span class=\"err\">with HTML named color</span>\n",
+       "<span class=\"err\">with custom named string</span>\n",
+       "<span class=\"err\">with hex code string</span>\n",
+       "<span class=\"err\">with rgb command string</span>\n",
+       "<span class=\"err\">with rgba command string</span>\n",
+       "<span class=\"err\">with hsl command string</span>\n",
+       "<span class=\"err\">with hsla command string</span>\n",
        "</pre></div>\n"
       ],
       "text/latex": [
        "\\begin{Verbatim}[commandchars=\\\\\\{\\}]\n",
        "\\PY{err}{f}\\PY{err}{i}\\PY{err}{l}\\PY{err}{l}\\PY{err}{\\PYZus{}}\\PY{err}{s}\\PY{err}{t}\\PY{err}{y}\\PY{err}{l}\\PY{err}{e}\\PY{err}{ }\\PY{err}{r}\\PY{err}{e}\\PY{err}{n}\\PY{err}{d}\\PY{err}{e}\\PY{err}{r}\\PY{err}{s}\\PY{err}{ }\\PY{err}{f}\\PY{err}{i}\\PY{err}{l}\\PY{err}{l}\\PY{err}{ }\\PY{err}{c}\\PY{err}{o}\\PY{err}{l}\\PY{err}{o}\\PY{err}{r}\\PY{err}{ }\n",
+       "\\PY{err}{w}\\PY{err}{i}\\PY{err}{t}\\PY{err}{h}\\PY{err}{ }\\PY{err}{H}\\PY{err}{T}\\PY{err}{M}\\PY{err}{L}\\PY{err}{ }\\PY{err}{n}\\PY{err}{a}\\PY{err}{m}\\PY{err}{e}\\PY{err}{d}\\PY{err}{ }\\PY{err}{c}\\PY{err}{o}\\PY{err}{l}\\PY{err}{o}\\PY{err}{r}\n",
+       "\\PY{err}{w}\\PY{err}{i}\\PY{err}{t}\\PY{err}{h}\\PY{err}{ }\\PY{err}{c}\\PY{err}{u}\\PY{err}{s}\\PY{err}{t}\\PY{err}{o}\\PY{err}{m}\\PY{err}{ }\\PY{err}{n}\\PY{err}{a}\\PY{err}{m}\\PY{err}{e}\\PY{err}{d}\\PY{err}{ }\\PY{err}{s}\\PY{err}{t}\\PY{err}{r}\\PY{err}{i}\\PY{err}{n}\\PY{err}{g}\n",
+       "\\PY{err}{w}\\PY{err}{i}\\PY{err}{t}\\PY{err}{h}\\PY{err}{ }\\PY{err}{h}\\PY{err}{e}\\PY{err}{x}\\PY{err}{ }\\PY{err}{c}\\PY{err}{o}\\PY{err}{d}\\PY{err}{e}\\PY{err}{ }\\PY{err}{s}\\PY{err}{t}\\PY{err}{r}\\PY{err}{i}\\PY{err}{n}\\PY{err}{g}\n",
+       "\\PY{err}{w}\\PY{err}{i}\\PY{err}{t}\\PY{err}{h}\\PY{err}{ }\\PY{err}{r}\\PY{err}{g}\\PY{err}{b}\\PY{err}{ }\\PY{err}{c}\\PY{err}{o}\\PY{err}{m}\\PY{err}{m}\\PY{err}{a}\\PY{err}{n}\\PY{err}{d}\\PY{err}{ }\\PY{err}{s}\\PY{err}{t}\\PY{err}{r}\\PY{err}{i}\\PY{err}{n}\\PY{err}{g}\n",
+       "\\PY{err}{w}\\PY{err}{i}\\PY{err}{t}\\PY{err}{h}\\PY{err}{ }\\PY{err}{r}\\PY{err}{g}\\PY{err}{b}\\PY{err}{a}\\PY{err}{ }\\PY{err}{c}\\PY{err}{o}\\PY{err}{m}\\PY{err}{m}\\PY{err}{a}\\PY{err}{n}\\PY{err}{d}\\PY{err}{ }\\PY{err}{s}\\PY{err}{t}\\PY{err}{r}\\PY{err}{i}\\PY{err}{n}\\PY{err}{g}\n",
+       "\\PY{err}{w}\\PY{err}{i}\\PY{err}{t}\\PY{err}{h}\\PY{err}{ }\\PY{err}{h}\\PY{err}{s}\\PY{err}{l}\\PY{err}{ }\\PY{err}{c}\\PY{err}{o}\\PY{err}{m}\\PY{err}{m}\\PY{err}{a}\\PY{err}{n}\\PY{err}{d}\\PY{err}{ }\\PY{err}{s}\\PY{err}{t}\\PY{err}{r}\\PY{err}{i}\\PY{err}{n}\\PY{err}{g}\n",
+       "\\PY{err}{w}\\PY{err}{i}\\PY{err}{t}\\PY{err}{h}\\PY{err}{ }\\PY{err}{h}\\PY{err}{s}\\PY{err}{l}\\PY{err}{a}\\PY{err}{ }\\PY{err}{c}\\PY{err}{o}\\PY{err}{m}\\PY{err}{m}\\PY{err}{a}\\PY{err}{n}\\PY{err}{d}\\PY{err}{ }\\PY{err}{s}\\PY{err}{t}\\PY{err}{r}\\PY{err}{i}\\PY{err}{n}\\PY{err}{g}\n",
        "\\end{Verbatim}\n"
       ],
       "text/plain": [
-       "fill_style renders fill color "
+       "fill_style renders fill color \n",
+       "with HTML named color\n",
+       "with custom named string\n",
+       "with hex code string\n",
+       "with rgb command string\n",
+       "with rgba command string\n",
+       "with hsl command string\n",
+       "with hsla command string"
       ]
      },
      "metadata": {},
@@ -863,7 +883,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -960,7 +980,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ab3d4f0f2bd94a44806c5c9b64524e1f",
+       "model_id": "c474f1e422694475a110083c1b793196",
        "version_major": 2,
        "version_minor": 0
       },

--- a/test/RandTest.ipynb
+++ b/test/RandTest.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -91,16 +91,16 @@
        ".output_html .vg { color: #19177C } /* Name.Variable.Global */\n",
        ".output_html .vi { color: #19177C } /* Name.Variable.Instance */\n",
        ".output_html .vm { color: #19177C } /* Name.Variable.Magic */\n",
-       ".output_html .il { color: #666666 } /* Literal.Number.Integer.Long */</style><div class=\"highlight\"><pre><span></span><span class=\"err\">Stopped due to inactivity</span>\n",
+       ".output_html .il { color: #666666 } /* Literal.Number.Integer.Long */</style><div class=\"highlight\"><pre><span></span><span class=\"err\">Stopped</span>\n",
        "</pre></div>\n"
       ],
       "text/latex": [
        "\\begin{Verbatim}[commandchars=\\\\\\{\\}]\n",
-       "\\PY{err}{S}\\PY{err}{t}\\PY{err}{o}\\PY{err}{p}\\PY{err}{p}\\PY{err}{e}\\PY{err}{d}\\PY{err}{ }\\PY{err}{d}\\PY{err}{u}\\PY{err}{e}\\PY{err}{ }\\PY{err}{t}\\PY{err}{o}\\PY{err}{ }\\PY{err}{i}\\PY{err}{n}\\PY{err}{a}\\PY{err}{c}\\PY{err}{t}\\PY{err}{i}\\PY{err}{v}\\PY{err}{i}\\PY{err}{t}\\PY{err}{y}\n",
+       "\\PY{err}{S}\\PY{err}{t}\\PY{err}{o}\\PY{err}{p}\\PY{err}{p}\\PY{err}{e}\\PY{err}{d}\n",
        "\\end{Verbatim}\n"
       ],
       "text/plain": [
-       "Stopped due to inactivity"
+       "Stopped"
       ]
      },
      "metadata": {},
@@ -109,7 +109,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6a5c407611d5431884c4a312f1a4610a",
+       "model_id": "6f176a16e9214550a0f11951d1322cd0",
        "version_major": 2,
        "version_minor": 0
       },
@@ -123,7 +123,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "58a689c46eeb490896b83563745e9043",
+       "model_id": "75dbc6faf5cc434e9aed751fb2e18de4",
        "version_major": 2,
        "version_minor": 0
       },

--- a/test/RandTest.ipynb
+++ b/test/RandTest.ipynb
@@ -12,17 +12,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
        "<style>pre { line-height: 125%; margin: 0; }\n",
-       "td.linenos pre { color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px; }\n",
-       "span.linenos { color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px; }\n",
-       "td.linenos pre.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }\n",
-       "span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }\n",
+       "td.linenos pre { color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px; }\n",
+       "span.linenos { color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px; }\n",
+       "td.linenos pre.special { color: #000000; background-color: #ffffc0; padding: 0 5px 0 5px; }\n",
+       "span.linenos.special { color: #000000; background-color: #ffffc0; padding: 0 5px 0 5px; }\n",
        ".output_html .hll { background-color: #ffffcc }\n",
        ".output_html { background: #f8f8f8; }\n",
        ".output_html .c { color: #408080; font-style: italic } /* Comment */\n",
@@ -91,16 +91,16 @@
        ".output_html .vg { color: #19177C } /* Name.Variable.Global */\n",
        ".output_html .vi { color: #19177C } /* Name.Variable.Instance */\n",
        ".output_html .vm { color: #19177C } /* Name.Variable.Magic */\n",
-       ".output_html .il { color: #666666 } /* Literal.Number.Integer.Long */</style><div class=\"highlight\"><pre><span></span><span class=\"err\">Running...</span>\n",
+       ".output_html .il { color: #666666 } /* Literal.Number.Integer.Long */</style><div class=\"highlight\"><pre><span></span><span class=\"err\">Stopped due to inactivity</span>\n",
        "</pre></div>\n"
       ],
       "text/latex": [
        "\\begin{Verbatim}[commandchars=\\\\\\{\\}]\n",
-       "\\PY{err}{R}\\PY{err}{u}\\PY{err}{n}\\PY{err}{n}\\PY{err}{i}\\PY{err}{n}\\PY{err}{g}\\PY{err}{.}\\PY{err}{.}\\PY{err}{.}\n",
+       "\\PY{err}{S}\\PY{err}{t}\\PY{err}{o}\\PY{err}{p}\\PY{err}{p}\\PY{err}{e}\\PY{err}{d}\\PY{err}{ }\\PY{err}{d}\\PY{err}{u}\\PY{err}{e}\\PY{err}{ }\\PY{err}{t}\\PY{err}{o}\\PY{err}{ }\\PY{err}{i}\\PY{err}{n}\\PY{err}{a}\\PY{err}{c}\\PY{err}{t}\\PY{err}{i}\\PY{err}{v}\\PY{err}{i}\\PY{err}{t}\\PY{err}{y}\n",
        "\\end{Verbatim}\n"
       ],
       "text/plain": [
-       "Running..."
+       "Stopped due to inactivity"
       ]
      },
      "metadata": {},
@@ -109,7 +109,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8d57f36d05cf41de84895326d9c6bab4",
+       "model_id": "6a5c407611d5431884c4a312f1a4610a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -123,7 +123,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b2767c187c2c451da8973c0d27271d10",
+       "model_id": "58a689c46eeb490896b83563745e9043",
        "version_major": 2,
        "version_minor": 0
       },
@@ -138,10 +138,10 @@
      "data": {
       "text/html": [
        "<style>pre { line-height: 125%; margin: 0; }\n",
-       "td.linenos pre { color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px; }\n",
-       "span.linenos { color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px; }\n",
-       "td.linenos pre.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }\n",
-       "span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }\n",
+       "td.linenos pre { color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px; }\n",
+       "span.linenos { color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px; }\n",
+       "td.linenos pre.special { color: #000000; background-color: #ffffc0; padding: 0 5px 0 5px; }\n",
+       "span.linenos.special { color: #000000; background-color: #ffffc0; padding: 0 5px 0 5px; }\n",
        ".output_html .hll { background-color: #ffffcc }\n",
        ".output_html { background: #f8f8f8; }\n",
        ".output_html .c { color: #408080; font-style: italic } /* Comment */\n",
@@ -269,6 +269,13 @@
     "        \n",
     "    "
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",

--- a/test/RectAndCircleTest.ipynb
+++ b/test/RectAndCircleTest.ipynb
@@ -109,7 +109,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0bb204beb5054906889b8c4b723517f7",
+       "model_id": "902dad25563c488fa358094b992f4cb1",
        "version_major": 2,
        "version_minor": 0
       },
@@ -223,7 +223,7 @@
     "    square(200, 100, 30)\n",
     "    \n",
     "    fill_style('red')\n",
-    "    stroke_style(255, 100, 0)\n",
+    "    stroke_style(0, 255, 100)\n",
     "    circle(100, 100, 30)\n",
     "    fill_style(0, 0, 0, 0)\n",
     "    stroke_circle(100, 150, 30)\n",

--- a/test/RectAndCircleTest.ipynb
+++ b/test/RectAndCircleTest.ipynb
@@ -109,7 +109,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6420fdf967e44821bf09bc216ff27e75",
+       "model_id": "0bb204beb5054906889b8c4b723517f7",
        "version_major": 2,
        "version_minor": 0
       },
@@ -215,7 +215,6 @@
     "\n",
     "def setup():\n",
     "    size(300, 300)\n",
-    "    \n",
     "    fill_style(100, 100, 255, 0.8)\n",
     "    rect(10, 0, 100, 50)\n",
     "    stroke_rect(10, 60, 100, 50)\n",
@@ -256,7 +255,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/test/SyntaxError.ipynb
+++ b/test/SyntaxError.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -116,7 +116,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f068027c75fa4504bf09200380348732",
+       "model_id": "c663cf63252548fc951d87279990d6ad",
        "version_major": 2,
        "version_minor": 0
       },
@@ -250,7 +250,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/test/SyntaxError.ipynb
+++ b/test/SyntaxError.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -116,7 +116,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c663cf63252548fc951d87279990d6ad",
+       "model_id": "3c421e3ca7c04a998aef8f877731b221",
        "version_major": 2,
        "version_minor": 0
       },

--- a/test/TriangleTest.ipynb
+++ b/test/TriangleTest.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -109,7 +109,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "82a84cf109014ea89ad5e6fddaaa6d96",
+       "model_id": "7e1c13cdf28f4c72b1a0a49b39d811ae",
        "version_major": 2,
        "version_minor": 0
       },


### PR DESCRIPTION
Moves all drawing functions to their own file, adds the `@extern` decorator to include external methods in the Core object. I am slightly concerned about performance, as there is now a lot of indirect calling, and a fair amount of redundancy. The indirectness should be mitigated by the manner in which Python operates, and I'm looking into solutions to reduce redundant calls.

This solution is more complex than we'd possibly like, and I am happy to hear feedback.